### PR TITLE
PSake BizTalk helper module

### DIFF
--- a/biztalk.psm1
+++ b/biztalk.psm1
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 if ($env:BTSINSTALLPATH) {
   Add-Type -Path "$env:BTSINSTALLPATH\Developer Tools\Microsoft.BizTalk.ExplorerOM.dll"


### PR DESCRIPTION
Includes support for creating and removing BizTalk applications, adding and
removing references, starting and stopping host instances and exporting
a BizTalk application as an MSI.
