### PR TITLE
Added helper methods for Duplicate and InspectCode

### DIFF
--- a/teamcity.psm1
+++ b/teamcity.psm1
@@ -72,6 +72,14 @@ function TeamCity-ImportFxCopResult([string]$path) {
 	TeamCity-WriteServiceMessage 'importData' @{ type='FxCop'; path=$path }
 }
 
+function TeamCity-ImportDuplicatesResult([string]$path) {
+	TeamCity-WriteServiceMessage 'importData' @{ type='DotNetDupFinder'; path=$path }
+}
+
+function TeamCity-ImportInspectionCodeResult([string]$path) {
+	TeamCity-WriteServiceMessage 'importData' @{ type='ReSharperInspectCode'; path=$path }
+}
+
 function TeamCity-ImportNUnitReport([string]$path) {
 	TeamCity-WriteServiceMessage 'importData' @{ type='nunit'; path=$path }
 }


### PR DESCRIPTION
In the same way that you can use Service Messages to import FxCop, it is also possible to import reports that are generated from the command line tools DupFinder and InspectCode