### PR TITLE
Added support for service message "buildProblem"

### DIFF
--- a/teamcity.psm1
+++ b/teamcity.psm1
@@ -138,6 +138,16 @@ function TeamCity-ReportBuildStatus([string]$status=$null, [string]$text='') {
 	TeamCity-WriteServiceMessage 'buildStatus' $messageAttributes
 }
 
+function TeamCity-ReportBuildProblem([string]$description, [string]$identity=$null) {
+	$messageAttributes = @{ description=$description }
+
+	if (![string]::IsNullOrEmpty($identity)) {
+		$messageAttributes.identity=$identity
+	}
+
+	TeamCity-WriteServiceMessage 'buildProblem' $messageAttributes
+}
+
 function TeamCity-SetBuildNumber([string]$buildNumber) {
 	TeamCity-WriteServiceMessage 'buildNumber' $buildNumber
 }

--- a/tests/teamcity.tests.ps1
+++ b/tests/teamcity.tests.ps1
@@ -218,6 +218,18 @@ Describe "TeamCity-ReportBuildStatus" {
     }
 }
 
+Describe "TeamCity-ReportBuildProblem" {
+    It "Writes ##teamcity[buildProblem description='A problem occured.' identity='SOME_IDENTITY']" {
+        TeamCity-ReportBuildProblem "A problem occured." "SOME_IDENTITY" | `
+          Should BeExactly "##teamcity[buildProblem description='A problem occured.' identity='SOME_IDENTITY']"
+    }
+    
+    It "Writes ##teamcity[buildStatus text='A problem occured.'] without optional identity attribute." {
+        TeamCity-ReportBuildStatus -text "A problem occured." | `
+          Should BeExactly "##teamcity[buildStatus text='A problem occured.']"
+    }
+}
+
 Describe "TeamCity-SetBuildNumber" {
     It "Writes ##teamcity[buildNumber '1.2.3_{build.number}-ent']" {
         TeamCity-SetBuildNumber "1.2.3_{build.number}-ent" | `


### PR DESCRIPTION
Since TeamCity 7.1 a failing build status should be reported via "buildReport" service message. This pull request adds support for these kind of service messages.
